### PR TITLE
wip: wasm component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 coverage/
 dist/
 .emscripten/
+.wit-bindgen/
 .e2e-results/
 .run-playwright/
 

--- a/argon2.wit
+++ b/argon2.wit
@@ -1,0 +1,37 @@
+package phi-ag:argon2;
+
+interface types {
+  enum argon2-type {
+    argon2d,
+    argon2i,
+    argon2id
+  }
+
+  enum argon2-version {
+    version10,
+    version13,
+  }
+
+  record options {
+    hash-length: option<u32>,
+    time-cost: option<u32>,
+    memory-cost: option<u32>,
+    parallelism: option<u32>,
+    argon2-type: option<argon2-type>,
+    argon2-version: option<argon2-version>
+  }
+
+  record data {
+    encoded: string,
+    // TODO: Use fixed size lists, see https://github.com/bytecodealliance/wit-bindgen/pull/1277
+    hash: tuple<u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8>
+  }
+}
+
+world argon2 {
+  use types.{argon2-type, options, data};
+
+  export initialize: func();
+  export hash: func(password: string, salt: list<u8>, options: option<options>) -> result<data, string>;
+  export verify: func(encoded: string, password: string, argon2-type: option<argon2-type>) -> result<bool, string>;
+}


### PR DESCRIPTION
WASM component experiment

`wit-bindgen c argon2.wit --out-dir .wit-bindgen/`

https://github.com/bytecodealliance/wit-bindgen
https://component-model.bytecodealliance.org/design/wit.html
https://bytecodealliance.org/articles/invoking-component-functions-in-wasmtime-cli

```
wasmtime run --invoke _initialize src/argon2.wasm
wasmtime run --invoke argon2_error_message src/argon2.wasm 0
```

https://www.heise.de/hintergrund/WebAssembly-WASI-und-Rust-Dreamteam-fuer-Microservices-9978208.html?seite=2
https://opensource.microsoft.com/blog/2024/09/25/distributing-webassembly-components-using-oci-registries/